### PR TITLE
Add Sky Serve infrastructure scaffolding

### DIFF
--- a/company_infra/LICENSE
+++ b/company_infra/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/company_infra/README.md
+++ b/company_infra/README.md
@@ -1,0 +1,40 @@
+# Company Infra
+
+This directory contains infrastructure configuration for the Brisingr project
+using [Sky Serve](https://sky.cs.berkeley.edu/).
+
+## Layout
+
+```
+company_infra/
+├─ docker/
+│  └─ llm.Dockerfile
+├─ env/
+│  ├─ base-requirements.txt
+│  ├─ llm-requirements.txt
+│  └─ vision-requirements.txt
+├─ sky/
+│  ├─ base-cluster.yaml
+│  ├─ llm-workload.yaml
+│  └─ vision-workload.yaml
+└─ scripts/
+   └─ launch_workload.py
+```
+
+## Usage
+
+1. **Launch cluster**
+   ```bash
+   sky launch -c company_infra/sky/base-cluster.yaml
+   ```
+2. **Serve an LLM**
+   ```bash
+   sky serve up -c company_infra/sky/llm-workload.yaml
+   ```
+3. **Serve a vision model (example)**
+   ```bash
+   sky serve up -c company_infra/sky/vision-workload.yaml
+   ```
+
+Adjust dependency versions and model paths in the requirements files and
+scripts as needed.

--- a/company_infra/docker/llm.Dockerfile
+++ b/company_infra/docker/llm.Dockerfile
@@ -1,0 +1,18 @@
+FROM python:3.10-slim
+
+# System dependencies
+RUN apt-get update && apt-get install -y git && rm -rf /var/lib/apt/lists/*
+
+# Base Python dependencies
+COPY env/base-requirements.txt /tmp/
+RUN pip install --no-cache-dir -r /tmp/base-requirements.txt
+
+# LLM-specific dependencies
+COPY env/llm-requirements.txt /tmp/
+RUN pip install --no-cache-dir -r /tmp/llm-requirements.txt
+
+# Copy project
+WORKDIR /app
+COPY . .
+
+CMD ["bash"]

--- a/company_infra/env/base-requirements.txt
+++ b/company_infra/env/base-requirements.txt
@@ -1,0 +1,2 @@
+numpy
+grpcio

--- a/company_infra/env/llm-requirements.txt
+++ b/company_infra/env/llm-requirements.txt
@@ -1,0 +1,3 @@
+rllm @ git+https://github.com/rllm-project/rllm.git
+vllm==0.10.1
+verl==0.5.0

--- a/company_infra/env/vision-requirements.txt
+++ b/company_infra/env/vision-requirements.txt
@@ -1,0 +1,1 @@
+# Add vision-specific dependencies here, e.g., torch, torchvision

--- a/company_infra/scripts/launch_workload.py
+++ b/company_infra/scripts/launch_workload.py
@@ -1,0 +1,19 @@
+import sys
+import subprocess
+
+WORKLOADS = {
+    "llm": "python -m vllm.entrypoints.api_server --model path/or/name",
+    "vision": "python -m my_vision_server",
+}
+
+def main() -> None:
+    if len(sys.argv) < 2:
+        raise SystemExit("Usage: launch_workload.py [workload]")
+    workload = sys.argv[1]
+    cmd = WORKLOADS.get(workload)
+    if cmd is None:
+        raise SystemExit(f"Unknown workload: {workload}")
+    subprocess.run(cmd, shell=True, check=True)
+
+if __name__ == "__main__":
+    main()

--- a/company_infra/sky/base-cluster.yaml
+++ b/company_infra/sky/base-cluster.yaml
@@ -1,0 +1,10 @@
+name: brisingr-cluster
+resources:
+  cloud: aws
+  region: us-west-2
+  instance_type: p3.2xlarge
+  ports: [8080]
+  image:
+    dockerfile: ../docker/llm.Dockerfile
+    workdir: /app
+    reqs: ../env/base-requirements.txt

--- a/company_infra/sky/llm-workload.yaml
+++ b/company_infra/sky/llm-workload.yaml
@@ -1,0 +1,7 @@
+name: llm-workload
+resources:
+  file_mounts: {}
+  setup: |
+    pip install -r env/llm-requirements.txt
+  run: |
+    python scripts/launch_workload.py llm

--- a/company_infra/sky/vision-workload.yaml
+++ b/company_infra/sky/vision-workload.yaml
@@ -1,0 +1,7 @@
+name: vision-workload
+resources:
+  file_mounts: {}
+  setup: |
+    pip install -r env/vision-requirements.txt
+  run: |
+    python scripts/launch_workload.py vision


### PR DESCRIPTION
## Summary
- add `company_infra` directory with Dockerfile, requirements, Sky Serve configs, and launcher script
- support modular LLM and example vision workloads via separate Sky Serve YAMLs

## Testing
- `python -m py_compile company_infra/scripts/launch_workload.py`


------
https://chatgpt.com/codex/tasks/task_e_68b88b5ee0d0832ab0134fd94a3cdb30